### PR TITLE
Added error builder object

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/metrics/PushMetricsEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/metrics/PushMetricsEndpoint.java
@@ -19,7 +19,7 @@ package org.jboss.aerogear.unifiedpush.rest.metrics;
 import org.jboss.aerogear.unifiedpush.api.FlatPushMessageInformation;
 import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dto.MessageMetrics;
-import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
+import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
 
 import javax.inject.Inject;
@@ -74,7 +74,7 @@ public class PushMetricsEndpoint {
         }
 
         if (id == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested information")).build();
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forMetrics().notFound().build()).build();
         }
 
         PageResult<FlatPushMessageInformation, MessageMetrics> pageResult =

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
@@ -19,7 +19,7 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
-import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
+import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
@@ -77,11 +77,11 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
         Variant variant = variantService.findByVariantID(variantId);
 
         if (variant == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
         }
 
         if (!type.isInstance(variant)) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(new UnifiedPushError("Requested Variant is of another type/platform")).build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(ErrorBuilder.forVariants().wrongType().build()).build();
         }
 
         logger.trace("Resetting secret for: {}", variant.getName());
@@ -112,11 +112,11 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
         Variant variant = variantService.findByVariantID(variantId);
 
         if (variant == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
         }
 
         if (!type.isInstance(variant)) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(new UnifiedPushError("Requested Variant is of another type/platform")).build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(ErrorBuilder.forVariants().wrongType().build()).build();
         }
 
         return Response.ok(variant).build();
@@ -140,11 +140,11 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
         Variant variant = variantService.findByVariantID(variantId);
 
         if (variant == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
         }
 
         if (!type.isInstance(variant)) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(new UnifiedPushError("Requested Variant is of another type/platform")).build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(ErrorBuilder.forVariants().wrongType().build()).build();
         }
 
         logger.trace("Deleting: {}", variant.getClass().getSimpleName());

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -18,7 +18,7 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
-import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
+import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
 import javax.validation.ConstraintViolationException;
@@ -69,7 +69,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
         PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
 
         if (pushApp == null) {
-            return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
+            return Response.status(Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
         }
 
         // some validation
@@ -152,7 +152,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
             return Response.ok(androidVariant).build();
         }
 
-        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
+        return Response.status(Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
     }
 
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/InstallationManagementEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/InstallationManagementEndpoint.java
@@ -19,7 +19,7 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dto.Count;
-import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
+import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.resteasy.spi.Link;
@@ -82,7 +82,7 @@ public class InstallationManagementEndpoint {
 
         //Find the variant using the variantID
         if (!searchManager.getSearchService().existsVariantIDForDeveloper(variantId)) {
-            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
         }
 
         //Find the installations using the variantID
@@ -136,7 +136,7 @@ public class InstallationManagementEndpoint {
         Installation installation = clientInstallationService.findById(installationId);
 
         if (installation == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Installation")).build();
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forInstallations().notFound().build()).build();
         }
 
         return Response.ok(installation).build();
@@ -162,7 +162,7 @@ public class InstallationManagementEndpoint {
         Installation installation = clientInstallationService.findById(installationId);
 
         if (installation == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Installation")).build();
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forInstallations().notFound().build()).build();
         }
 
         clientInstallationService.updateInstallation(installation, entity);
@@ -189,7 +189,7 @@ public class InstallationManagementEndpoint {
         Installation installation = clientInstallationService.findById(installationId);
 
         if (installation == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Installation")).build();
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forInstallations().notFound().build()).build();
         }
 
         // remove it

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/PushApplicationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/PushApplicationEndpoint.java
@@ -22,7 +22,7 @@ import org.jboss.aerogear.unifiedpush.dao.InstallationDao;
 import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dto.Count;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
-import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
+import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
@@ -189,7 +189,7 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
             return response.build();
         }
 
-        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
+        return Response.status(Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
     }
 
     private void putActivityIntoResponseHeaders(PushApplication app, ResponseBuilder response) {
@@ -248,7 +248,7 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
             return Response.noContent().build();
         }
 
-        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
+        return Response.status(Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
     }
 
     /**
@@ -279,7 +279,7 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
             return Response.ok(pushApp).build();
         }
 
-        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
+        return Response.status(Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
     }
 
     /**
@@ -303,7 +303,7 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
             pushAppService.removePushApplication(pushApp);
             return Response.noContent().build();
         }
-        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
+        return Response.status(Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
     }
 
     /**

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
@@ -19,7 +19,7 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
 import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
-import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
+import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 
 import javax.validation.ConstraintViolationException;
@@ -67,7 +67,7 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint<WebPushVaria
         PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
 
         if (pushApp == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
         }
 
         // some validation
@@ -136,6 +136,6 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint<WebPushVaria
             return Response.ok(webPushVariant).build();
         }
 
-        return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
+        return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
     }
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpoint.java
@@ -21,7 +21,7 @@ import org.jboss.aerogear.unifiedpush.api.iOSTokenVariant;
 import org.jboss.aerogear.unifiedpush.message.jms.APNSClientProducer;
 import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
 import org.jboss.aerogear.unifiedpush.rest.annotations.PATCH;
-import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
+import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 
 import javax.inject.Inject;
@@ -81,7 +81,7 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
         PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
 
         if (pushApp == null) {
-            return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
+            return Response.status(Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
         }
 
         // some model validation on the entity:
@@ -157,7 +157,7 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
             variantService.updateVariant(iOSTokenVariant);
             return Response.noContent().build();
         }
-        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
+        return Response.status(Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
     }
 
     /**
@@ -210,6 +210,6 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
 
             return Response.ok(iOSTokenVariant).build();
         }
-        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
+        return Response.status(Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
     }
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -21,7 +21,7 @@ import org.jboss.aerogear.unifiedpush.api.iOSVariant;
 import org.jboss.aerogear.unifiedpush.message.jms.APNSClientProducer;
 import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
 import org.jboss.aerogear.unifiedpush.rest.annotations.PATCH;
-import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
+import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.rest.util.iOSApplicationUploadForm;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
@@ -77,7 +77,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
         PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
 
         if (pushApp == null) {
-            return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
+            return Response.status(Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
         }
 
         // some model validation on the uploaded form
@@ -100,7 +100,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
         iOSVariant.setProduction(form.getProduction());
         iOSVariant.setVariantID(form.getVariantID());
         iOSVariant.setSecret(form.getSecret());
-        
+
         // some model validation on the entity:
         try {
             validateModelClass(iOSVariant);
@@ -169,7 +169,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
             variantService.updateVariant(iOSVariant);
             return Response.noContent().build();
         }
-        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
+        return Response.status(Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
     }
 
     /**
@@ -233,6 +233,6 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
 
             return Response.ok(iOSVariant).build();
         }
-        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
+        return Response.status(Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
     }
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -24,7 +24,7 @@ import org.jboss.aerogear.unifiedpush.api.validation.DeviceTokenValidator;
 import org.jboss.aerogear.unifiedpush.auth.HttpBasicHelper;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
 import org.jboss.aerogear.unifiedpush.rest.EmptyJSON;
-import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
+import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
 import org.jboss.aerogear.unifiedpush.service.metrics.PrometheusExporter;
@@ -371,7 +371,7 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
         return appendAllowOriginHeader(
                 Response.status(Status.UNAUTHORIZED)
                         .header("WWW-Authenticate", "Basic realm=\"AeroGear UnifiedPush Server\"")
-                        .entity(new UnifiedPushError("Unauthorized Request")),
+                        .entity(ErrorBuilder.forAuth().unauthorized().build()),
                 request);
     }
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
@@ -22,7 +22,7 @@ import org.jboss.aerogear.unifiedpush.message.InternalUnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.NotificationRouter;
 import org.jboss.aerogear.unifiedpush.rest.EmptyJSON;
 import org.jboss.aerogear.unifiedpush.rest.util.HttpRequestUtil;
-import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
+import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
 import org.jboss.aerogear.unifiedpush.service.metrics.PrometheusExporter;
 import org.slf4j.Logger;
@@ -95,7 +95,7 @@ public class PushNotificationSenderEndpoint {
         if (pushApplication == null) {
             return Response.status(Status.UNAUTHORIZED)
                     .header("WWW-Authenticate", "Basic realm=\"AeroGear UnifiedPush Server\"")
-                    .entity(new UnifiedPushError("Unauthorized Request"))
+                    .entity(ErrorBuilder.forAuth().unauthorized().build())
                     .build();
         }
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/HealthCheck.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/HealthCheck.java
@@ -17,7 +17,7 @@
 package org.jboss.aerogear.unifiedpush.rest.util;
 
 import org.jboss.aerogear.unifiedpush.message.HealthNetworkService;
-import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
+import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.service.HealthDBService;
 import org.jboss.aerogear.unifiedpush.service.impl.health.HealthDetails;
 import org.jboss.aerogear.unifiedpush.service.impl.health.HealthStatus;
@@ -103,7 +103,7 @@ public class HealthCheck {
         try (final InputStream manifestStream = context.getResourceAsStream("/META-INF/MANIFEST.MF")) {
             return Response.ok(new Manifest(manifestStream).getMainAttributes()).build();
         } catch (Exception e) {
-            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find version information")).build();
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forHealthCheck().noVersion().build()).build();
         }
     }
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/ErrorBuilder.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/ErrorBuilder.java
@@ -1,0 +1,117 @@
+package org.jboss.aerogear.unifiedpush.rest.util.error;
+
+public abstract class ErrorBuilder {
+    private ErrorBuilder() {
+    }
+
+    public static VariantErrorBuilder forVariants() {
+        return new VariantErrorBuilder();
+    }
+
+    public static PushApplicationErrorBuilder forPushApplications() {
+        return new PushApplicationErrorBuilder();
+    }
+
+    public static InstallationErrorBuilder forInstallations() {
+        return new InstallationErrorBuilder();
+    }
+
+    public static AuthErrorBuilder forAuth() {
+        return new AuthErrorBuilder();
+    }
+
+    public static HealthCheckErrorBuilder forHealthCheck() {
+        return new HealthCheckErrorBuilder();
+    }
+
+    public static MetricsErrorBuilder forMetrics() {
+        return new MetricsErrorBuilder();
+    }
+
+
+    // Actual builders
+    private static class AbstractErrorBuilder<T extends AbstractErrorBuilder<T>> {
+        private UnifiedPushError error = new UnifiedPushError("Unknown error");
+
+        protected T setError(UnifiedPushError error) {
+            this.error = error;
+            return (T)this;
+        }
+
+        protected UnifiedPushError getError() {
+            return this.error;
+        }
+
+        public final UnifiedPushError build() {
+            return error;
+        }
+        public final T withDetail(final String key, final String value) {
+            this.error.addDetail(key, value);
+            return (T)this;
+        }
+
+        public final T withRootException(Throwable exc) {
+            this.error.setRootException(exc);
+            return (T)this;
+        }
+    }
+
+    public static class VariantErrorBuilder extends AbstractErrorBuilder<VariantErrorBuilder> {
+        private VariantErrorBuilder() {
+        }
+
+        public VariantErrorBuilder notFound() {
+            return this.setError(new UnifiedPushError("Could not find requested Variant"));
+        }
+
+        public VariantErrorBuilder wrongType() {
+            return this.setError(new UnifiedPushError("Requested Variant is of another type/platform"));
+        }
+    }
+
+    public static class PushApplicationErrorBuilder extends AbstractErrorBuilder<PushApplicationErrorBuilder> {
+        private PushApplicationErrorBuilder() {
+        }
+
+        public PushApplicationErrorBuilder notFound() {
+            return this.setError(new UnifiedPushError("Could not find requested PushApplicationEntity"));
+        }
+    }
+
+    public static class InstallationErrorBuilder extends AbstractErrorBuilder<InstallationErrorBuilder> {
+        private InstallationErrorBuilder() {
+        }
+
+        public InstallationErrorBuilder notFound() {
+            return this.setError(new UnifiedPushError("Could not find requested Installation"));
+        }
+    }
+
+    public static class AuthErrorBuilder extends AbstractErrorBuilder<AuthErrorBuilder> {
+        private AuthErrorBuilder() {
+        }
+
+        public AuthErrorBuilder unauthorized() {
+            return this.setError(new UnifiedPushError("Unauthorized Request"));
+        }
+    }
+
+    public static class MetricsErrorBuilder extends AbstractErrorBuilder<MetricsErrorBuilder> {
+        private MetricsErrorBuilder() {
+        }
+
+        public MetricsErrorBuilder notFound() {
+            return this.setError(new UnifiedPushError("Could not find version information"));
+        }
+    }
+
+
+    public static class HealthCheckErrorBuilder extends AbstractErrorBuilder<HealthCheckErrorBuilder> {
+        private HealthCheckErrorBuilder() {
+        }
+
+        public HealthCheckErrorBuilder noVersion() {
+            return this.setError(new UnifiedPushError("Could not find version information"));
+        }
+    }
+}

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/UnifiedPushError.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/UnifiedPushError.java
@@ -1,13 +1,33 @@
 package org.jboss.aerogear.unifiedpush.rest.util.error;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 public class UnifiedPushError {
     private final String message;
+    private final Map<String, String> details = new HashMap<>();
+    private Throwable rootException;
 
-    public UnifiedPushError(String message) {
+    UnifiedPushError(String message) {
         this.message = message;
+    }
+
+    void addDetail(final String key, final String value) {
+        this.details.put(key, value);
+    }
+
+    void setRootException(Throwable exc) {
+        this.rootException = exc;
     }
 
     public String getMessage() {
         return message;
+    }
+    public Map<String, String> getDetails() {
+        return Collections.unmodifiableMap(this.details);
+    }
+    public Throwable getRootException() {
+        return this.rootException;
     }
 }


### PR DESCRIPTION
# Motivation
Instead of having the error messages in free form an ErrorBuilder object has been added to guide through the creation of an error object.

A root exception and a map of details have been added too (both optional)